### PR TITLE
Continue list and correct node type

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -90,7 +90,8 @@ class KrknKubernetes:
             self.__kubeconfig_string = kubeconfig_string
             self.__initialize_clients_from_kconfig_string(kubeconfig_string)
 
-        else:
+        if kubeconfig_path is not None:
+            self.__kubeconfig_path = kubeconfig_path
             self.__initialize_clients(kubeconfig_path)
             self.__kubeconfig_path = kubeconfig_path
 

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -248,7 +248,6 @@ class KrknKubernetes:
         :return: list of namespaces json data
         """
 
-        namespaces = []
         try:
             if label_selector:
                 ret = self.list_continue_helper(self.cli.list_namespace,

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -71,12 +71,12 @@ class KrknKubernetes:
 
         Initialization with kubeconfig path:
 
-        >>> KrknKubernetes(log_writer, "/home/test/.kube/config", )
+        >>> KrknKubernetes(log_writer, "/home/test/.kube/config")
 
         Initialization with kubeconfig string:
 
         >>> kubeconfig_string="apiVersion: v1 ....."
-        >>> KrknKubernetes(log_writer, kubeconfig_string=kubeconfig_string, r)
+        >>> KrknKubernetes(log_writer, kubeconfig_string=kubeconfig_string)
         """
 
         if kubeconfig_string is not None and kubeconfig_path is not None:
@@ -85,7 +85,6 @@ class KrknKubernetes:
                 "or a valid kubeconfig string"
             )
 
-        self.__kubeconfig_path = kubeconfig_path
         self.request_chunk_size = request_chunk_size
         if kubeconfig_string is not None:
             self.__kubeconfig_string = kubeconfig_string
@@ -93,6 +92,7 @@ class KrknKubernetes:
 
         else:
             self.__initialize_clients(kubeconfig_path)
+            self.__kubeconfig_path = kubeconfig_path
 
     def __del__(self):
         self.api_client.rest_client.pool_manager.clear()

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -91,7 +91,6 @@ class KrknKubernetes:
             self.__initialize_clients_from_kconfig_string(kubeconfig_string)
 
         if kubeconfig_path is not None:
-            self.__kubeconfig_path = kubeconfig_path
             self.__initialize_clients(kubeconfig_path)
             self.__kubeconfig_path = kubeconfig_path
 

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -41,6 +41,7 @@ SERVICE_CERT_FILENAME = "/var/run/secrets/k8s.io/serviceaccount/ca.crt"
 class KrknKubernetes:
     """ """
 
+    request_chunk_size: int = 250
     api_client: client.ApiClient = None
     cli: client.CoreV1Api = None
     batch_cli: client.BatchV1Api = None
@@ -56,6 +57,7 @@ class KrknKubernetes:
         kubeconfig_path: str = None,
         *,
         kubeconfig_string: str = None,
+        request_chunk_size: int = 250
     ):
         """
         KrknKubernetes Constructor. Can be invoked with kubeconfig_path
@@ -82,19 +84,18 @@ class KrknKubernetes:
                 "or a valid kubeconfig string"
             )
 
+        self.__kubeconfig_path = kubeconfig_path
         if kubeconfig_string is not None:
-            self.__initialize_clients_from_kconfig_string(kubeconfig_string)
-            self.__kubeconfig_string = kubeconfig_string
+            self.__initialize_clients_from_kconfig_string(kubeconfig_string, request_chunk_size)
         else:
-            self.__initialize_clients(kubeconfig_path)
-            self.__kubeconfig_path = kubeconfig_path
+            self.__initialize_clients(kubeconfig_path,request_chunk_size)
 
     def __del__(self):
         self.api_client.rest_client.pool_manager.clear()
         self.api_client.close()
 
     # Load kubeconfig and initialize k8s python client
-    def __initialize_clients(self, kubeconfig_path: str = None):
+    def __initialize_clients(self, kubeconfig_path: str = None, request_chunk_size: int = 250):
         """
         Initialize all clients from kubeconfig path
 
@@ -139,6 +140,7 @@ class KrknKubernetes:
             )
             self.dyn_client = DynamicClient(self.k8s_client)
             self.watch_resource = watch.Watch()
+            self.request_chunk_size = request_chunk_size
         except OSError:
             raise Exception(
                 "Invalid kube-config file: {0}. "
@@ -148,6 +150,7 @@ class KrknKubernetes:
     def __initialize_clients_from_kconfig_string(
         self,
         kubeconfig_str: str,
+        request_chunk_size: int
     ):
         """
         Initialize all clients from kubeconfig yaml string
@@ -171,6 +174,7 @@ class KrknKubernetes:
                 self.api_client
             )
             self.dyn_client = DynamicClient(self.api_client)
+            self.request_chunk_size = request_chunk_size
         except ApiException as e:
             logging.error("Failed to initialize k8s client: %s\n", str(e))
             raise e
@@ -225,6 +229,7 @@ class KrknKubernetes:
             while continue_string:
                 ret = func(*args, **keyword_args, _continue=continue_string)
                 ret_overall.append(ret)
+                
                 continue_string = ret.metadata._continue
 
         except ApiException as e:
@@ -245,19 +250,20 @@ class KrknKubernetes:
         namespaces = []
         try:
             if label_selector:
-                ret = self.cli.list_namespace(
-                    pretty=True, label_selector=label_selector
+                ret = self.list_continue_helper(self.cli.list_namespace,
+                    pretty=True, label_selector=label_selector,limit=self.request_chunk_size
                 )
             else:
-                ret = self.list_continue_helper(self.cli.list_namespace,pretty=True)
+                ret = self.list_continue_helper(self.cli.list_namespace,pretty=True, limit=self.request_chunk_size)
         except ApiException as e:
             logging.error(
                 "Exception when calling CoreV1Api->list_namespaced_pod: %s\n",
                 str(e),
             )
             raise e
-        for namespace in ret.items:
-            namespaces.append(namespace.metadata.name)
+        for ret_list in ret: 
+            for namespace in ret_list.items:
+                namespaces.append(namespace.metadata.name)
         return namespaces
 
     def get_namespace_status(self, namespace_name: str) -> str:
@@ -315,7 +321,7 @@ class KrknKubernetes:
         :return: a list of matching namespaces
         """
         try:
-            valid_namespaces = self.list_continue_helper(self.list_namespaces,label_selector)
+            valid_namespaces = self.list_namespaces(label_selector)
             regex_namespaces = set(namespaces) - set(valid_namespaces)
             final_namespaces = set(namespaces) - set(regex_namespaces)
             valid_regex = set()
@@ -351,10 +357,10 @@ class KrknKubernetes:
         try:
             if label_selector:
                 ret = self.list_continue_helper(self.cli.list_node,
-                    pretty=True, label_selector=label_selector
+                    pretty=True, label_selector=label_selector, limit=self.request_chunk_size
                 )
             else:
-                ret = self.list_continue_helper(self.cli.list_node,pretty=True)
+                ret = self.list_continue_helper(self.cli.list_node,pretty=True, limit=self.request_chunk_size)
         except ApiException as e:
             logging.error(
                 "Exception when calling CoreV1Api->list_node: %s\n", str(e)
@@ -450,10 +456,10 @@ class KrknKubernetes:
         try:
             if label_selector:
                 ret = self.list_continue_helper(self.cli.list_namespaced_pod,
-                    namespace, pretty=True, label_selector=label_selector
+                    namespace, pretty=True, label_selector=label_selector, limit=self.request_chunk_size
                 )
             else:
-                ret = self.list_continue_helper(self.cli.list_namespaced_pod,namespace, pretty=True)
+                ret = self.list_continue_helper(self.cli.list_namespaced_pod,namespace, pretty=True, limit=self.request_chunk_size)
         except ApiException as e:
             logging.error(
                 "Exception when calling CoreV1Api->list_namespaced_pod: %s\n",
@@ -635,10 +641,10 @@ class KrknKubernetes:
         pods = []
         if label_selector:
             ret = self.list_continue_helper(self.cli.list_pod_for_all_namespaces,
-                pretty=True, label_selector=label_selector
+                pretty=True, label_selector=label_selector, limit=self.request_chunk_size
             )
         else:
-            ret = self.list_continue_helper(self.cli.list_pod_for_all_namespaces,pretty=True)
+            ret = self.list_continue_helper(self.cli.list_pod_for_all_namespaces,pretty=True, limit=self.request_chunk_size)
         for pod in ret.items:
             pods.append([pod.metadata.name, pod.metadata.namespace])
         return pods
@@ -709,6 +715,20 @@ class KrknKubernetes:
         for serv in ret.items:
             services.append(serv.metadata.name)
         return services
+    # Outputs a json blob with informataion about all pods in a given namespace
+    def get_all_pod_info(self, namespace: str = "default") -> list[str]:
+        """
+        Get details of all pods in a namespace
+
+        :param namespace: namespace (optional default `default`)
+        :return list of pod details
+        """
+        try:
+            ret = self.list_continue_helper(self.cli.list_namespaced_pod,namespace, limit=self.request_chunk_size)
+        except ApiException as e:
+            logging.error("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+
+        return ret
 
     # to be tested, return value not sure
     def exec_cmd_in_pod(
@@ -1723,41 +1743,44 @@ class KrknKubernetes:
         :return: the list of NodeInfo objects
         """
         instance_type_label = "node.k8s.io/instance-type"
-        node_type_master_label = "node-role.k8s.io/master"
-        node_type_worker_label = "node-role.k8s.io/worker"
-        node_type_infra_label = "node-role.k8s.io/infra"
-        node_type_workload_label = "node-role.k8s.io/workload"
-        node_type_application_label = "node-role.k8s.io/app"
+        node_type_master_label = "node-role.kubernetes.io/master"
+        node_type_worker_label = "node-role.kubernetes.io/worker"
+        node_type_infra_label = "node-role.kubernetes.io/infra"
+        node_type_workload_label = "node-role.kubernetes.io/workload"
+        node_type_application_label = "node-role.kubernetes.io/app"
         result = list[NodeInfo]()
-        resp = self.list_continue_helper(self.cli.list_node)
-        for node in resp.items:
-            node_info = NodeInfo()
-            if instance_type_label in node.metadata.labels.keys():
-                node_info.instance_type = node.metadata.labels[
-                    instance_type_label
-                ]
-            else:
-                node_info.instance_type = "unknown"
+        resp = self.list_continue_helper(self.cli.list_node, limit=self.request_chunk_size)
+        for node_resp in resp: 
+            for node in node_resp.items:
+                node_info = NodeInfo(taint=node.spec.taints)
+                if instance_type_label in node.metadata.labels.keys():
+                    node_info.instance_type = node.metadata.labels[
+                        instance_type_label
+                    ]
+                else:
+                    node_info.instance_type = "unknown"
 
-            if node_type_infra_label in node.metadata.labels.keys():
-                node_info.node_type = "infra"
-            elif node_type_worker_label in node.metadata.labels.keys():
-                node_info.node_type = "worker"
-            elif node_type_master_label in node.metadata.labels.keys():
-                node_info.node_type = "master"
-            elif node_type_workload_label in node.metadata.labels.keys():
-                node_info.node_type = "workload"
-            elif node_type_application_label in node.metadata.labels.keys():
-                node_info.node_type = "application"
-            else:
-                node_info.node_type = "unknown"
+                if node_type_infra_label in node.metadata.labels.keys():
+                    node_info.node_type = "infra"
+                elif node_type_worker_label in node.metadata.labels.keys():
+                    node_info.node_type = "worker"
+                elif node_type_master_label in node.metadata.labels.keys():
+                    node_info.node_type = "master"
+                elif node_type_workload_label in node.metadata.labels.keys():
+                    node_info.node_type = "workload"
+                elif node_type_application_label in node.metadata.labels.keys():
+                    node_info.node_type = "application"
+                else:
+                    node_info.node_type = "unknown"
+                
 
-            node_info.architecture = node.status.node_info.architecture
-            node_info.kernel_version = node.status.node_info.kernel_version
-            node_info.kubelet_version = node.status.node_info.kubelet_version
-            node_info.os_version = node.status.node_info.os_image
-            result.append(node_info)
-
+                node_info.name = node.metadata.name
+                node_info.architecture = node.status.node_info.architecture
+                node_info.architecture = node.status.node_info.architecture
+                node_info.kernel_version = node.status.node_info.kernel_version
+                node_info.kubelet_version = node.status.node_info.kubelet_version
+                node_info.os_version = node.status.node_info.os_image
+                result.append(node_info)
         return result
 
     def delete_file_from_pod(

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -76,6 +76,14 @@ class NodeInfo:
     """
     Cluster node telemetry informations
     """
+    taint: dict 
+    """
+    Taint on the node"""
+
+    name: str = ""
+    """
+    Name of the node
+    """
 
     architecture: str = ""
     """

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -72,6 +72,25 @@ class KrknKubernetesTests(BaseTest):
             test_kubeconfig = test.read()
             self.assertEqual(test_kubeconfig, kubeconfig_str)
 
+
+    def test_list_all_namespaces(self):
+        # test list all namespaces
+        result = self.lib_k8s.list_all_namespaces()
+        self.assertTrue(len(result) > 1)
+        # test filter by label
+        result = self.lib_k8s.list_all_namespaces(
+            "kubernetes.io/metadata.name=default"
+        )
+        print('result type' + str(type(result)))
+        self.assertTrue(len(result) == 1)
+        self.assertIn("default", result)
+
+        # test unexisting filter
+        result = self.lib_k8s.list_namespaces(
+            "k8s.io/metadata.name=donotexist"
+        )
+        self.assertTrue(len(result) == 0)
+
     def test_list_namespaces(self):
         # test all namespaces
         result = self.lib_k8s.list_namespaces()

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -76,14 +76,23 @@ class KrknKubernetesTests(BaseTest):
     def test_list_all_namespaces(self):
         # test list all namespaces
         result = self.lib_k8s.list_all_namespaces()
-        self.assertTrue(len(result) > 1)
+        result_count = 0
+        for r in result:
+            for item in r.items:
+                result_count+=1
+        print('result type' + str((result_count)))
+        self.assertTrue(result_count > 1)
         # test filter by label
         result = self.lib_k8s.list_all_namespaces(
             "kubernetes.io/metadata.name=default"
         )
-        print('result type' + str(type(result)))
+       
         self.assertTrue(len(result) == 1)
-        self.assertIn("default", result)
+        namespace_names = []
+        for r in result:
+            for item in r.items:
+                namespace_names.append(item.metadata.name)
+        self.assertIn("default", namespace_names)
 
         # test unexisting filter
         result = self.lib_k8s.list_namespaces(


### PR DESCRIPTION
For cerberus I had introduced the ability to chunk the requests and be able to continue getting results if there are more than the chunk size (this helps with large scale clusters)

There are a lot of changes here so I want to be sure that the updates are all tested appropriately. I have tested for cerberus, will test within krkn as well 

I also noticed that the node type is unknown always so I updated that: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-redhat-chaos-krkn-hub-main-rosa-4.14-nightly-ocp-qe-perfscale-ci-tests-rosa/1729545735780700160