### PR TITLE
Taking out wait after service delete

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -634,10 +634,6 @@ class KrknKubernetes:
         """
         try:
             self.cli.delete_namespaced_service(name, namespace)
-            while self.cli.read_namespaced_service(
-                name=name, namespace=namespace
-            ):
-                time.sleep(1)
         except ApiException as e:
             if e.status == 404:
                 logging.info("Service already deleted")


### PR DESCRIPTION
Some namespaces recreate services very quickly that the wait times out in our CI systems