### PR TITLE
Fixes the calculated parameter error when end_time is None

### DIFF
--- a/src/krkn_lib/prometheus/krkn_prometheus.py
+++ b/src/krkn_lib/prometheus/krkn_prometheus.py
@@ -38,8 +38,8 @@ class KrknPrometheus:
     def process_prom_query_in_range(
         self,
         query: str,
-        start_time: datetime = datetime.now() - timedelta(days=1),
-        end_time: datetime = datetime.now(),
+        start_time: datetime = None,
+        end_time: datetime = None,
     ) -> list[dict[str:any]]:
         """
         Executes a query to the Prometheus API in PromQL language
@@ -50,6 +50,12 @@ class KrknPrometheus:
 
         :return: a list of records in dictionary format
         """
+        start_time = (
+            datetime.now() - timedelta(days=1)
+            if start_time is None
+            else start_time
+        )
+        end_time = datetime.now() if end_time is None else end_time
 
         granularity = math.ceil(
             (end_time - start_time).total_seconds() / 11000


### PR DESCRIPTION
If datetime.now() is defined as default parameter value, the date is calculated at the moment the intepreter defines the function and not when the function is called (as I thought), that's the reason why the start_time is considered greater than the end_time by the prometheus API as explained [here](https://stackoverflow.com/questions/62399546/python-datetime-now-as-a-default-function-parameter-return-same-value-in-diffe). 
This change fixes the issue.